### PR TITLE
devops(ci): add publish stage in ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.1.10
+          virtualenvs-create: true
+          virtualenvs-in-project: false
+          virtualenvs-path: /home/runner/.cache/pypoetry/virtualenvs
+          installer-parallel: true
+      - name: Publsh package
+        env:
+            PYPI_USERNAME:  ${{ secrets.PYPI_USERNAME }}
+            PYPI_PASSWORD : ${{ secrets.PYPI_PASSWORD }}
+        run:
+          poetry publish  --username $PYPI_USERNAME --password  $PYPI_PASSWORD --build

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This will do it all for you.
 
 ## Documentation
 All official documentation hosted [here](https://skonik.github.io/django-swap-user-docs/).
+The documentation repo is located [here](https://github.com/skonik/django-swap-user-docs).
 
 ## Installation
 ```


### PR DESCRIPTION
## Description of changes
This PR adds a new stage  which builds and publishes python package to PYPI.

## Before merging 
Please  make sure that you've added `PYPI_USERNAME` and  `PYPI_PASSWORD` to your repository secrtes.

## How to use
Create tags for the repository
1. ```git tag -a v0.9.9 -m "New version"```

Push tags

2. ```git push origin --tags```

After that github-actions will trigger job to publish the package